### PR TITLE
Update model loading to be compliant with new versions of tensorflow

### DIFF
--- a/sarwaveifrproc/config.yaml
+++ b/sarwaveifrproc/config.yaml
@@ -1,5 +1,6 @@
-model_intraburst: 'model_intraburst.keras'
-model_interburst: 'model_interburst.keras'
+model_version: '1.0.0'
+model_intraburst: 'model_intraburst.h5'
+model_interburst: 'model_interburst.h5'
 scaler_intraburst: 'scaler_intraburst.npy'
 scaler_interburst: 'scaler_interburst.npy'
 bins_intraburst: 'bins_intraburst'

--- a/sarwaveifrproc/models.py
+++ b/sarwaveifrproc/models.py
@@ -1,0 +1,48 @@
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Dense, Concatenate, Input, Dropout
+
+def get_model(version):
+    """
+    Retrieves a neural network model builder function based on the specified version.
+
+    Parameters:
+    - version (str): A string indicating the version of the model to retrieve.
+
+    Returns:
+    - model_builder (function): A function that builds the specified version of the neural network model.
+    """
+    model_builders = {'1.0.0': build_model_v1_0_0,
+                      '1.0.1': build_model_v1_0_0}
+
+    return model_builders[version]
+
+
+def build_model_v1_0_0(nb_classes):
+    """
+    Builds a neural network model corresponding to the version v1.0.0.
+
+    Parameters:
+    - nb_classes (list or tuple): A list or tuple containing the number of output classes for each output layer.
+
+    Returns:
+    - model (keras.Model): A compiled Keras model with the specified architecture.
+
+    Architecture:
+    - Input layer: 24 features.
+    - 10 Dense layers, each with 1024 neurons and ReLU activation.
+    - Output layer: Concatenation of output layers with a number of neurons specified by nb_classes.
+
+    """
+    input_shape = (24, )
+    X_input = Input(input_shape)
+    
+    X = Dense(1024, activation='relu')(X_input)
+    for i in range(9):
+        X = Dense(1024, activation='relu')(X)
+        
+    X_output = Concatenate()([Dense(n)(X) for n in nb_classes])
+    
+    model = Model(inputs=X_input, outputs=X_output)
+    model.compile()
+
+    return model


### PR DESCRIPTION
This pull request includes :
1) Model loading update in order to be compliant with new versions of tensorflow :
- new models.py file which stores the model architectures;
- config.yaml modified accordingly (output bins are now necessary to load the neural models).

2) It is now possible to give a config_path in order to switch easily between model versions.
ex: `L2-wave-processor --input_path S1_...SAFE --save_directory /savedir --product_id E99 --config_path /localconfig_17km.yaml`

3) Help display speed using `L2-wave-processor -h` or `--help`  has been increased by managing imports.
